### PR TITLE
RF_AT_003.10.15 Footer > Social media module > Icons-links visibility and сlickability > Verify image correctness in the Facebook brand-link

### DIFF
--- a/pages/main_page.py
+++ b/pages/main_page.py
@@ -329,11 +329,6 @@ class MainPage(BasePage):
         image = self.find_element(self.locators.FACEBOOK_IMAGE)
         assert image.is_displayed(), "The image is not visible in the Facebook brand-link"
 
-    def check_image_is_correct_in_facebook_brand_link(self):
-        image_src = self.find_element(self.locators.FACEBOOK_IMAGE).get_attribute("src")
-        assert image_src == FooterImageUrls.FACEBOOK_IMAGE_URL, \
-            "The image is not correct in the Facebook brand-link"
-
     def check_twitter_link_visibility(self):
         twitter_link = self.driver.find_element(*self.locators.TWITTER_LINK)
         assert twitter_link.is_displayed(), "The Twitter brand-link is not visible"

--- a/tests/test_main_page_ow6.py
+++ b/tests/test_main_page_ow6.py
@@ -244,7 +244,9 @@ class TestMainPage:
 
     def test_tc_003_10_15_verify_image_correctness_in_facebook_brand_link(self, driver, open_and_load_main_page):
         page = MainPage(driver)
-        page.check_image_is_correct_in_facebook_brand_link()
+        facebook_image = page.find_element(MainPageLocators.FACEBOOK_IMAGE)
+        facebook_image_url = FooterImageUrls.FACEBOOK_IMAGE_URL
+        page.check_image_is_correct_in_the_element(facebook_image, facebook_image_url)
 
     def test_tc_003_10_16_verify_display_of_twitter_brand_link(self, driver, open_and_load_main_page):
         page = MainPage(driver)


### PR DESCRIPTION
https://trello.com/c/ZHDNUtxx/2311-at0031032-footer-social-media-module-icons-links-visibility-and-%D1%81lickability-verify-image-presence-in-the-github-brand-link