### PR TITLE
RF_AT_003.10.14 Footer > Social media module > Icons-links visibility and сlickability > Verify image visibility in the Facebook brand-link

### DIFF
--- a/pages/main_page.py
+++ b/pages/main_page.py
@@ -321,10 +321,6 @@ class MainPage(BasePage):
         facebook_link = self.driver.find_element(*self.locators.FACEBOOK_LINK)
         assert facebook_link.is_enabled(), "The Facebook brand-link is not clickable"
 
-    def check_image_is_visible_in_facebook_link(self):
-        image = self.find_element(self.locators.FACEBOOK_IMAGE)
-        assert image.is_displayed(), "The image is not visible in the Facebook brand-link"
-
     def check_twitter_link_visibility(self):
         twitter_link = self.driver.find_element(*self.locators.TWITTER_LINK)
         assert twitter_link.is_displayed(), "The Twitter brand-link is not visible"

--- a/tests/test_main_page_ow6.py
+++ b/tests/test_main_page_ow6.py
@@ -241,7 +241,9 @@ class TestMainPage:
 
     def test_tc_003_10_14_verify_image_visibility_in_facebook_brand_link(self, driver, open_and_load_main_page):
         page = MainPage(driver)
-        page.check_image_is_visible_in_facebook_link()
+        facebook_image = page.find_element(MainPageLocators.FACEBOOK_IMAGE)
+        page.go_to_element(facebook_image)
+        page.check_element_image_is_visible(facebook_image)
 
     def test_tc_003_10_15_verify_image_correctness_in_facebook_brand_link(self, driver, open_and_load_main_page):
         page = MainPage(driver)


### PR DESCRIPTION
https://trello.com/c/5xQH6UIZ/2281-rfat0031014-footer-social-media-module-icons-links-visibility-and-%D1%81lickability-verify-image-visibility-in-the-facebook-brand-lin