### PR TITLE
AT_003.10.33 Footer > Social media module > Icons-links visibility and сlickability > Verify image visibility in the GitHub brand-link

### DIFF
--- a/tests/test_main_page_ow6.py
+++ b/tests/test_main_page_ow6.py
@@ -340,6 +340,12 @@ class TestMainPage:
         github_image = page.find_element(MainPageLocators.GITHUB_IMAGE)
         page.check_image_is_present_in_the_element(github_image)
 
+    def test_tc_003_10_33_verify_image_visibility_in_github_brand_link(self, driver, open_and_load_main_page):
+        page = MainPage(driver)
+        github_image = page.find_element(MainPageLocators.GITHUB_IMAGE)
+        page.go_to_element(github_image)
+        page.check_element_image_is_visible(github_image)
+
     def test_tc_003_12_01_check_historical_weather_data_link_functionality(self, driver, open_and_load_main_page):
         page = MainPage(driver)
         page.check_historical_weather_data_link_functionality()


### PR DESCRIPTION
https://trello.com/c/94Y16Kfw/2319-at0031033-footer-social-media-module-icons-links-visibility-and-%D1%81lickability-verify-image-visibility-in-the-github-brand-link