### PR TITLE
RF_AT_003.09.07 Footer > Download OpenWeather app module > Visibility, structure, links сlickability > Verify image presence in Download on the App Store brand-link (#1070)

### DIFF
--- a/pages/main_page.py
+++ b/pages/main_page.py
@@ -287,9 +287,9 @@ class MainPage(BasePage):
         assert element_text == text, \
             f"Actual text '{element_text}' of the Download OpenWeather app module title does not match expected '{text}'"
 
-    def check_image_is_present_in_download_on_the_app_store_link(self):
-        image = self.find_element(self.locators.DOWNLOAD_ON_THE_APP_STORE_IMAGE)
-        assert image is not None, "The image is not present in the Download on the App Store brand-link"
+    # def check_image_is_present_in_download_on_the_app_store_link(self):
+    #     image = self.find_element(self.locators.DOWNLOAD_ON_THE_APP_STORE_IMAGE)
+    #     assert image is not None, "The image is not present in the Download on the App Store brand-link"
 
     def check_image_is_visible_in_download_on_the_app_store_link(self):
         image = self.find_element(self.locators.DOWNLOAD_ON_THE_APP_STORE_IMAGE)

--- a/tests/test_main_page_ow6.py
+++ b/tests/test_main_page_ow6.py
@@ -201,7 +201,8 @@ class TestMainPage:
 
     def test_tc_003_09_07_verify_image_presence_in_download_on_the_app_store_link(self, driver, open_and_load_main_page):
         page = MainPage(driver)
-        page.check_image_is_present_in_download_on_the_app_store_link()
+        download_on_the_app_store_image = page.find_element(MainPageLocators.DOWNLOAD_ON_THE_APP_STORE_IMAGE)
+        page.check_image_is_present_in_the_element(download_on_the_app_store_image)
 
     def test_tc_003_09_08_verify_image_visibility_in_download_on_the_app_store_link(self, driver,
                                                                                     open_and_load_main_page):


### PR DESCRIPTION
https://trello.com/c/5T5I5ocq/2262-rfat0030907-footer-download-openweather-app-module-visibility-structure-links-%D1%81lickability-verify-image-presence-in-download-on