### PR TITLE
RF_AT_003.09.08 Footer > Download OpenWeather app module > Visibility, structure, links сlickability > Verify image visibility in "Download on the App Store" brand-link (#1071)

### DIFF
--- a/pages/main_page.py
+++ b/pages/main_page.py
@@ -287,14 +287,6 @@ class MainPage(BasePage):
         assert element_text == text, \
             f"Actual text '{element_text}' of the Download OpenWeather app module title does not match expected '{text}'"
 
-    # def check_image_is_present_in_download_on_the_app_store_link(self):
-    #     image = self.find_element(self.locators.DOWNLOAD_ON_THE_APP_STORE_IMAGE)
-    #     assert image is not None, "The image is not present in the Download on the App Store brand-link"
-
-    def check_image_is_visible_in_download_on_the_app_store_link(self):
-        image = self.find_element(self.locators.DOWNLOAD_ON_THE_APP_STORE_IMAGE)
-        assert image.is_displayed(), "The image is not visible in the Download on the App Store brand-link"
-
     def check_image_is_correct_in_download_on_the_app_store_link(self):
         image_src = self.find_element(self.locators.DOWNLOAD_ON_THE_APP_STORE_IMAGE).get_attribute("src")
         assert image_src == FooterImageUrls.DOWNLOAD_ON_THE_APP_STORE_IMAGE_URL, \

--- a/tests/test_main_page_ow6.py
+++ b/tests/test_main_page_ow6.py
@@ -207,7 +207,9 @@ class TestMainPage:
     def test_tc_003_09_08_verify_image_visibility_in_download_on_the_app_store_link(self, driver,
                                                                                     open_and_load_main_page):
         page = MainPage(driver)
-        page.check_image_is_visible_in_download_on_the_app_store_link()
+        download_on_the_app_store_image = page.find_element(MainPageLocators.DOWNLOAD_ON_THE_APP_STORE_IMAGE)
+        page.go_to_element(download_on_the_app_store_image)
+        page.check_element_image_is_visible(download_on_the_app_store_image)
 
     def test_tc_003_09_09_verify_image_correctness_in_download_on_the_app_store_link(self, driver,
                                                                                     open_and_load_main_page):


### PR DESCRIPTION
https://trello.com/c/mLzStN06/2266-rfat0030908-footer-download-openweather-app-module-visibility-structure-links-%D1%81lickability-verify-image-visibility-in-download-o