### PR TITLE
AT_003.10.34 Footer > Social media module > Icons-links visibility and сlickability > Verify image correctness in the GitHub brand-link

### DIFF
--- a/test_data/urls.py
+++ b/test_data/urls.py
@@ -14,6 +14,7 @@ class FooterImageUrls:
     GET_IT_ON_GOOGLE_PLAY_IMAGE_URL = \
         "https://openweathermap.org/themes/openweathermap/assets/img/mobile_app/google-play-badge.png"
     FACEBOOK_IMAGE_URL = "https://openweathermap.org/themes/openweathermap/assets/img/owm_icons/icon_facebook.png"
+    GITHUB_IMAGE_URL = "https://openweathermap.org/themes/openweathermap/assets/img/owm_icons/icon_github.png"
     LINKEDIN_IMAGE_URL = "https://openweathermap.org/themes/openweathermap/assets/img/owm_icons/icon_linkedin.png"
     MEDIUM_IMAGE_URL = "https://openweathermap.org/themes/openweathermap/assets/img/owm_icons/icon_medium.png"
     TELEGRAM_IMAGE_URL = "https://openweathermap.org/themes/openweathermap/assets/img/owm_icons/icon_telegram.png"

--- a/tests/test_main_page_ow6.py
+++ b/tests/test_main_page_ow6.py
@@ -355,6 +355,12 @@ class TestMainPage:
         page.go_to_element(github_image)
         page.check_element_image_is_visible(github_image)
 
+    def test_tc_003_10_34_verify_image_correctness_in_github_brand_link(self, driver, open_and_load_main_page):
+        page = MainPage(driver)
+        github_image = page.find_element(MainPageLocators.GITHUB_IMAGE)
+        github_image_url = FooterImageUrls.GITHUB_IMAGE_URL
+        page.check_image_is_correct_in_the_element(github_image, github_image_url)
+
     def test_tc_003_12_01_check_historical_weather_data_link_functionality(self, driver, open_and_load_main_page):
         page = MainPage(driver)
         page.check_historical_weather_data_link_functionality()


### PR DESCRIPTION

https://trello.com/c/4qXXfGFR/2321-at0031034-footer-social-media-module-icons-links-visibility-and-%D1%81lickability-verify-image-correctness-in-the-github-brand-link
